### PR TITLE
Fixed client output in hops-slave.log, added reformat_cluster.sh script, etc

### DIFF
--- a/scripts/internals/HopsFS_Exp_Remote_Scripts/log4j.properties
+++ b/scripts/internals/HopsFS_Exp_Remote_Scripts/log4j.properties
@@ -1,4 +1,3 @@
-#
 #   Licensed to the Apache Software Foundation (ASF) under one or more
 #   contributor license agreements.  See the NOTICE file distributed with
 #   this work for additional information regarding copyright ownership.
@@ -18,10 +17,16 @@
 
 #HOP adding RFA for writing the log to file for manipulation using grep/glark
 
-log4j.rootLogger=ERROR, CA 
-hadoop.root.logger=DEBUG, CA
+log4j.rootLogger=INFO,stdout, CA 
+hadoop.root.logger=INFO,stdout, CA
+
 #Console Appender
 log4j.appender.CA=org.apache.log4j.ConsoleAppender
 log4j.appender.CA.layout=org.apache.log4j.PatternLayout
 log4j.appender.CA.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+#log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern= %d{HH:mm:ss,SSS} %5p [%t] [%F:%L] %x - %m%n
+
 

--- a/scripts/reformat_cluster.sh
+++ b/scripts/reformat_cluster.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This script formats the NN, DN, removes data dirs, and restarts the services.
+
+echo "1. Format namenode"
+/mnt/hadoop/sbin/format-nn.sh
+
+echo "2. Delete Datanode directories and runtime config"
+rm -rf /mnt/hopsdata/hdfs/dn/current/
+rm -rf /mnt/hopsdata/hdfs/nn/current/
+rm -rf /mnt/hadoop/logs/hadoop-*-datanode-ip-*.log
+rm -rf /mnt/hadoop/logs/hadoop-*-namenode-ip-*.log
+
+echo "3. reboot namenode"
+sudo service namenode restart
+
+echo "4. reboot datanode"
+sudo service datanode restart
+

--- a/src/main/java/io/hops/experiments/utils/DFSOperationsUtils.java
+++ b/src/main/java/io/hops/experiments/utils/DFSOperationsUtils.java
@@ -38,7 +38,7 @@ import io.hops.experiments.workload.generator.FileTreeGenerator;
 import io.hops.experiments.workload.generator.FixeDepthFileTreeGenerator;
 
 public class DFSOperationsUtils {
-
+    private static final boolean READ_WHOLE_FILE = true;
     private static final boolean SERVER_LESS_MODE=false; //only for testing. If enabled then the clients will not
     private static Random rand = new Random(System.currentTimeMillis());
                                                         // contact NNs
@@ -119,7 +119,7 @@ public class DFSOperationsUtils {
             byte b;
             do{
                 b = in.readByte();
-            }while(false);
+            } while(READ_WHOLE_FILE);
         }catch (EOFException e){
         }finally {
             in.close();

--- a/src/main/java/io/hops/experiments/utils/DFSOperationsUtils.java
+++ b/src/main/java/io/hops/experiments/utils/DFSOperationsUtils.java
@@ -38,7 +38,9 @@ import io.hops.experiments.workload.generator.FileTreeGenerator;
 import io.hops.experiments.workload.generator.FixeDepthFileTreeGenerator;
 
 public class DFSOperationsUtils {
+    // TODO: move to ConfigKeys
     private static final boolean READ_WHOLE_FILE = true;
+    
     private static final boolean SERVER_LESS_MODE=false; //only for testing. If enabled then the clients will not
     private static Random rand = new Random(System.currentTimeMillis());
                                                         // contact NNs
@@ -116,12 +118,19 @@ public class DFSOperationsUtils {
 
         FSDataInputStream in = dfs.open(new Path(pathStr));
         try {
-            byte b;
-            do{
-                b = in.readByte();
-            } while(READ_WHOLE_FILE);
-        }catch (EOFException e){
-        }finally {
+            if (READ_WHOLE_FILE) {
+                // read file in 64 KB chunks
+                byte[] buffer  = new byte[64*1024];
+                int read = 0;
+                do {
+                    read = in.read(buffer);
+                } while (read>0);    
+            } else {
+                // just open file and read a byte
+                in.readByte();
+            }
+        } catch (EOFException e) {
+        } finally {
             in.close();
         }
     }


### PR DESCRIPTION
Also moved/created READ_WHOLE_FILE constant to top of file.

The reformat_cluster.sh script is used to easily start a new run when testing the S3 HopsFS system (namenodes get stuck in safemode because of block report).